### PR TITLE
delete entries when auto-returned, instead of returning over and over 

### DIFF
--- a/openbare.spec
+++ b/openbare.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           openbare
-Version:        0.3.2
+Version:        0.3.3
 Release:        0
 Summary:        A digital asset library system, implemented on Django
 License:        GPL-3.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.3.2
+current_version = 0.3.3
 commit = True
 tag = True
 

--- a/tools/openbare-user-monitor
+++ b/tools/openbare-user-monitor
@@ -38,7 +38,12 @@ from library.models import *
 def checkin_expired_accounts():
     now = datetime.now(django.utils.timezone.UTC())
     for lendable in Lendable.all_types.filter(due_on__lte=now):
-        lendable.checkin()
+        try:
+            lendable.checkin()
+        except Exception as e:
+            logging.error(e)
+        else:
+            lendable.delete()
 
 
 def get_warning_message(lendable):


### PR DESCRIPTION
openbare-user-monitor was successfully performing checkin() on past-due lendables, but wasn't deleting the lendable record, so they appeared to require return again on the next run, and never appeared to be checked in according to the UI.