### PR TITLE
Config auth backends

### DIFF
--- a/library/templates/library/home.html
+++ b/library/templates/library/home.html
@@ -29,7 +29,9 @@
     </p>
     {% if not user or user.is_anonymous %}
     <p>
-      <a class="btn btn-success btn-lg" href="{% url 'social:begin' 'opensuse' %}?next={{ request.path }}">Log in</a>
+      {% for backend in backends.backends %}
+        <a class="btn btn-success btn-lg" href="{% url 'social:begin' backend %}?next={{ request.path }}">Login via {{ backend }}</a>
+      {% endfor %}
     </p>
     {% endif %}
   </div>

--- a/openbare.spec
+++ b/openbare.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           openbare
-Version:        0.3.2
+Version:        0.4.0
 Release:        0
 Summary:        A digital asset library system, implemented on Django
 License:        GPL-3.0

--- a/openbare/settings/base.py
+++ b/openbare/settings/base.py
@@ -110,7 +110,6 @@ STATICFILES_DIRS = (
 # python-social-auth
 
 AUTHENTICATION_BACKENDS = (
-    'social.backends.suse.OpenSUSEOpenId',
     'django.contrib.auth.backends.ModelBackend',
 )
 

--- a/production-setting-templates/settings_base.py.template
+++ b/production-setting-templates/settings_base.py.template
@@ -37,3 +37,8 @@ ADMINS = [
     ('Backup Administrator', 'openbare-admin-pool@yourdomain.com')
 ]
 
+# Which python-social-auth backends do you use for authentication?
+# Backend list: http://psa.matiasaguirre.net/docs/backends/index.html
+AUTHENTICATION_BACKENDS += (
+    'social.backends.suse.OpenSUSEOpenId',
+)

--- a/production-setting-templates/settings_base.py.template
+++ b/production-setting-templates/settings_base.py.template
@@ -37,13 +37,3 @@ ADMINS = [
     ('Backup Administrator', 'openbare-admin-pool@yourdomain.com')
 ]
 
-# How many renewals are allowed with each plugin?
-# Specify the plugin type, from library/models, and the number of renewals.
-MAX_RENEWALS = {
-    'amazondemoaccount': 2
-}
-
-# Number of days prior to due date when user is notified via email.
-# For example, send notifications 5 days, two days, and the day before due.
-EXPIRATION_NOTIFICATION_WARNING_DAYS = [5, 2, 1]
-

--- a/production-setting-templates/settings_library.py.template
+++ b/production-setting-templates/settings_library.py.template
@@ -1,0 +1,26 @@
+# Copyright © 2016 SUSE LLC, James Mason <jmason@suse.com>.
+#
+# This file is part of openbare.
+#
+# openbare is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# openbare is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with openbare. If not, see <http://www.gnu.org/licenses/>.
+
+# How many renewals are allowed with each plugin?
+# Specify the plugin type, from library/models, and the number of renewals.
+MAX_RENEWALS = {
+    'amazondemoaccount': 2
+}
+
+# Number of days prior to due date when user is notified via email.
+# For example, send notifications 5 days, two days, and the day before due.
+EXPIRATION_NOTIFICATION_WARNING_DAYS = [5, 2, 1]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.3.2
+current_version = 0.4.0
 commit = True
 tag = True
 


### PR DESCRIPTION
Intial design fixed the 'opensuse' auth backend in base settings, and the
login button was wired directly to it. As part of making the application more
accessible to a larger community, the auth backends needed to move out to
an external configuration option; this also allowed for enabling multiple
backends.