### PR TITLE
Downloadable credentials

### DIFF
--- a/library/templates/library/home.html
+++ b/library/templates/library/home.html
@@ -257,11 +257,16 @@
                 {% endfor %}
               </dl>
               <p>
-                Be sure to record these before closing this dialog, they cannot be presented again.
+                Be sure to
+                <a href="data:application/json;base64,{{ download_credentials_payload }}" target="_blank" download="{{ download_credentials_filename }}">
+                  download
+                </a>
+                or otherwise record these before closing this dialog, they cannot be presented again.
                 If you lose these credentials, you will have to return this item, and checkout the resource again.
               </p>
             </div>
             <div class="modal-footer">
+              <a href="data:application/json;base64,{{ download_credentials_payload }}" target="_blank" download="{{ download_credentials_filename }}" role="button" class="btn btn-default">Download Credentials</a>
             </div>
           </div>
         </div>


### PR DESCRIPTION
Provide an interface for downloading credentials, which are presented only at
checkout (and not persisted for user security).

Offering the download was complicated by not having persisted credentials, as
downloads typically require an additional request to the server - which no
longer has the credentials context.

The data: URI (https://developer.mozilla.org/en-US/docs/Web/HTTP/data_URIs ) in
addition to the download attribute of HTML links, allows offering a client-side
download from the existing checkout page, without an additonal round-trip to
the server (and the inherent requirement to persist user credentials).

Resolves issue https://github.com/openbare/openbare/issues/12